### PR TITLE
22w11a

### DIFF
--- a/PandamiumBuilderDatapack/data/build/functions/main_loop.mcfunction
+++ b/PandamiumBuilderDatapack/data/build/functions/main_loop.mcfunction
@@ -10,4 +10,10 @@ item replace entity @a[scores={permanent_elytra=1},nbt=!{Inventory:[{Slot:102b}]
 
 scoreboard players remove @a[scores={nether_portal_cooldown=1..}] nether_portal_cooldown 5
 
+execute in build:release/overworld run tp @e[type=#build:snapshot_entities,x=0] 0 -1000 0
+execute in build:release/the_nether run tp @e[type=#build:snapshot_entities,x=0] 0 -1000 0
+execute as @e[type=boat] if data entity @s {Type:"mangrove"} run kill
+execute in build:release/overworld run clear @a[x=0] #build:snapshot_items
+execute in build:release/the_nether run clear @a[x=0] #build:snapshot_items
+
 schedule function build:main_loop 5t

--- a/PandamiumBuilderDatapack/data/build/functions/misc/disabled_blocks/release.mcfunction
+++ b/PandamiumBuilderDatapack/data/build/functions/misc/disabled_blocks/release.mcfunction
@@ -1,4 +1,5 @@
-execute at @s run fill ~-10 ~-10 ~-10 ~10 ~10 ~10 air replace #build:disabled_blocks/release
+execute at @s run fill ~-10 ~-10 ~-10 ~10 ~10 ~10 air replace #build:disabled_blocks/release[waterlogged=false]
+execute at @s run fill ~-10 ~-10 ~-10 ~10 ~10 ~10 water replace #build:disabled_blocks/release[waterlogged=true]
 
 tellraw @s [{"text":"[Info]","color":"dark_red"},{"text":" That block is disabled in this dimension!","color":"red"}]
 

--- a/PandamiumBuilderDatapack/data/build/tags/entity_types/snapshot_entities.json
+++ b/PandamiumBuilderDatapack/data/build/tags/entity_types/snapshot_entities.json
@@ -1,0 +1,6 @@
+{
+	"values": [
+		"frog",
+		"tadpole"
+	]
+}

--- a/PandamiumBuilderDatapack/data/build/tags/items/snapshot_items.json
+++ b/PandamiumBuilderDatapack/data/build/tags/items/snapshot_items.json
@@ -1,6 +1,8 @@
 {
 	"values": [
+		"frog_spawn_egg",
 		"frogspawn",
+		"mangrove_boat",
 		"mangrove_button",
 		"mangrove_door",
 		"mangrove_fence",
@@ -15,7 +17,6 @@
 		"mangrove_slab",
 		"mangrove_stairs",
 		"mangrove_trapdoor",
-		"mangrove_wall_sign",
 		"mangrove_wood",
 		"mud",
 		"mud_brick_slab",
@@ -26,13 +27,14 @@
 		"ochre_froglight",
 		"packed_mud",
 		"pearlescent_froglight",
-		"potted_mangrove_propagule",
 		"sculk",
 		"sculk_catalyst",
 		"sculk_shrieker",
 		"sculk_vein",
 		"stripped_mangrove_log",
 		"stripped_mangrove_wood",
+		"tadpole_bucket",
+		"tadpole_spawn_egg",
 		"verdant_froglight"
 	]
 }

--- a/PandamiumBuilderDatapack/pack.mcmeta
+++ b/PandamiumBuilderDatapack/pack.mcmeta
@@ -1,6 +1,6 @@
 {
 	"pack": {
-		"pack_format": 8,
-		"description": "Pandamium Builder Datapack\nand BlingEdit (modified)"
+		"description": "Pandamium Builder Datapack\nand BlingEdit (modified)",
+		"pack_format": 10
 	}
 }


### PR DESCRIPTION
- Snapshot entities and blocks placed in the `release/*` dimensions will be removed automatically
- Updated the pack format